### PR TITLE
Updates for Saline

### DIFF
--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -2,7 +2,7 @@ var config_data = `
 {
   "dataFormat": "tsv",
   "title": "Scouting PASS 2025",
-  "page_title": "Reefscape 1502 Scouting v1.1",
+  "page_title": "Reefscape 1502 Scouting v1.101",
   "checkboxAs": "10",
   "prematch": [
     { "name": "Scouter name<br>(Firstname Lastname)",

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -55,6 +55,13 @@ var config_data = `
       "min": 1,
       "max": 99999
     },
+    { "name": "Team Name",
+      "code": "name",
+      "type": "text",
+      "size": 15,
+      "maxSize": 50,
+      "defaultValue": "Team Name"
+    }
     { "name": "Auto Start Position",
       "code": "as",
       "type": "clickable_image",
@@ -210,7 +217,7 @@ var config_data = `
       },
       "defaultValue":"3"
     },
-    { "name": "Died/Immobilized/Gamepiece Stuck",
+    { "name": "Died/<br>Immobilized/<br>Gamepiece Stuck",
       "code": "die",
       "type": "bool"
     },

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -129,6 +129,10 @@ var config_data = `
       "code": "tsg",
       "type": "counter"
     },
+    { "name": "Penalties",
+      "code": "pen",
+      "type": "counter"
+    },
     { "name": "Pickup Coral From",
       "code": "tpu",
       "type": "radio",

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -2,7 +2,7 @@ var config_data = `
 {
   "dataFormat": "tsv",
   "title": "Scouting PASS 2025",
-  "page_title": "Reefscape 1502 Scouting v1.101",
+  "page_title": "Reefscape 1502 Scouting v1.2",
   "checkboxAs": "10",
   "prematch": [
     { "name": "Scouter name<br>(Firstname Lastname)",

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -231,7 +231,8 @@ var config_data = `
       "code": "co",
       "type": "text",
       "size": 15,
-      "maxSize": 55
+      "maxSize": 250,
+      "defaultValue": "None"
     }
   ]
 }`;

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -176,7 +176,7 @@ var config_data = `
         "o": "High Cage<br>",
         "s": "Low Cage<br>",
         "a": "Attempted/Failed & Parked<br>",
-        "x": "No park/climb attempted"
+        "x": "No park or climb attempted"
       },
       "defaultValue": "x"
     }

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -61,7 +61,7 @@ var config_data = `
       "size": 15,
       "maxSize": 50,
       "defaultValue": "Team Name"
-    }
+    },
     { "name": "Auto Start Position",
       "code": "as",
       "type": "clickable_image",

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -175,8 +175,8 @@ var config_data = `
         "p": "Parked<br>",
         "o": "High Cage<br>",
         "s": "Low Cage<br>",
-        "a": "Attempted but failed<br>",
-        "x": "Not attempted"
+        "a": "Attempted/Failed & Parked<br>",
+        "x": "No park/climb attempted"
       },
       "defaultValue": "x"
     }

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -55,7 +55,7 @@ var config_data = `
       "min": 1,
       "max": 99999
     },
-    { "name": "Team Name",
+    { "name": "Team Name update 1",
       "code": "n",
       "type": "text",
       "size": 15,

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -5,7 +5,7 @@ var config_data = `
   "page_title": "Reefscape 1502 Scouting",
   "checkboxAs": "10",
   "prematch": [
-    { "name": "Scouter name (Firstname Lastname)",
+    { "name": "Scouter name<br>(Firstname Lastname)",
       "code": "s",
       "type": "scouter",
       "size": 15,
@@ -56,7 +56,7 @@ var config_data = `
       "max": 99999
     },
     { "name": "Team Name",
-      "code": "name",
+      "code": "n",
       "type": "text",
       "size": 15,
       "maxSize": 50,

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -2,7 +2,7 @@ var config_data = `
 {
   "dataFormat": "tsv",
   "title": "Scouting PASS 2025",
-  "page_title": "Reefscape 1502 Scouting",
+  "page_title": "Reefscape 1502 Scouting v1.1",
   "checkboxAs": "10",
   "prematch": [
     { "name": "Scouter name<br>(Firstname Lastname)",

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -210,7 +210,7 @@ var config_data = `
       },
       "defaultValue":"3"
     },
-    { "name": "Died/Immobilized",
+    { "name": "Died/Immobilized/Gamepiece Stuck",
       "code": "die",
       "type": "bool"
     },
@@ -222,9 +222,14 @@ var config_data = `
       "code": "dn",
       "type": "bool"
     },
-    { "name": "Make good<br>alliance partner?",
+    { "name": "Would pick<br>for an alliance?",
       "tooltip": "Would you want this robot on your alliance in eliminations?",
       "code": "all",
+      "type": "bool"
+    },
+    { "name": "Would NOT pick<br>for an alliance?",
+      "tooltip": "Would NOT pick this robot under any circumstances",
+      "code": "dnp",
       "type": "bool"
     },
     { "name": "Comments",

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -55,7 +55,7 @@ var config_data = `
       "min": 1,
       "max": 99999
     },
-    { "name": "Team Name update 1",
+    { "name": "Team Name update 2",
       "code": "n",
       "type": "text",
       "size": 15,

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -55,7 +55,7 @@ var config_data = `
       "min": 1,
       "max": 99999
     },
-    { "name": "Team Name update 2",
+    { "name": "Team Name update 3",
       "code": "n",
       "type": "text",
       "size": 15,

--- a/2024/crescendo_config.js
+++ b/2024/crescendo_config.js
@@ -5,7 +5,7 @@ var config_data = `
   "page_title": "Reefscape 1502 Scouting",
   "checkboxAs": "10",
   "prematch": [
-    { "name": "Scouter name",
+    { "name": "Scouter name (Firstname Lastname)",
       "code": "s",
       "type": "scouter",
       "size": 15,

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -1224,7 +1224,7 @@ function updateMatchStart(event) {
   if (event.target.id == "input_m") {
     if (getRobot() != "" && typeof getRobot()) {
       document.getElementById("input_t").value = getCurrentTeamNumberFromRobot().replace("frc", "");
-      document.getElementById("input_name").value = getTeamName(document.getElementById("input_t").value)
+      document.getElementById("input_name").value = getTeamName(document.getElementById("input_t").value);
       onTeamnameChange();
     }
   }

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -915,7 +915,7 @@ function clearForm() {
     }
 
     // Set default comment back to None
-    document.getElementById("input_Comments").value = "None"
+    document.getElementById("input_Comments").value = "Reset"
 
     // Robot
     resetRobot()

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -914,6 +914,9 @@ function clearForm() {
       document.getElementById("input_m").value = match + 1
     }
 
+    // Set default comment back to None
+    document.getElementById("input_Comments").value = "None"
+
     // Robot
     resetRobot()
   }

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -1224,7 +1224,6 @@ function updateMatchStart(event) {
   if (event.target.id == "input_m") {
     if (getRobot() != "" && typeof getRobot()) {
       document.getElementById("input_t").value = getCurrentTeamNumberFromRobot().replace("frc", "");
-      document.getElementById("input_n").value = getTeamName(document.getElementById("input_t").value);
       onTeamnameChange();
     }
   }
@@ -1237,6 +1236,7 @@ function onTeamnameChange(event) {
     teamLabel.innerText = getTeamName(newNumber) != "" ? "You are scouting " + getTeamName(newNumber) : "That team isn't playing this match, please double check to verify correct number";
   } else {
     teamLabel.innerText = "";
+    document.getElementById("input_n").value = teamLabel;
   }
 }
 

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -1232,12 +1232,12 @@ function updateMatchStart(event) {
 function onTeamnameChange(event) {
   var newNumber = document.getElementById("input_t").value;
   var teamLabel = document.getElementById("teamname-label");
-  document.getElementById("input_n").value = 'DanTeam' //getTeamName(newNumber);
+  document.getElementById("input_n").value = getTeamName(newNumber);
   if (newNumber != "") {
     teamLabel.innerText = getTeamName(newNumber) != "" ? "You are scouting " + getTeamName(newNumber) : "That team isn't playing this match, please double check to verify correct number";
   } else {
     teamLabel.innerText = "";
-    document.getElementById("input_n").value = 'DanTeam' //getTeamName(newNumber);
+    document.getElementById("input_n").value = getTeamName(newNumber);
   }
 }
 

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -1224,7 +1224,7 @@ function updateMatchStart(event) {
   if (event.target.id == "input_m") {
     if (getRobot() != "" && typeof getRobot()) {
       document.getElementById("input_t").value = getCurrentTeamNumberFromRobot().replace("frc", "");
-      document.getElementById("input_name").value = getTeamName(document.getElementById("input_t").value);
+      document.getElementById("input_n").value = getTeamName(document.getElementById("input_t").value);
       onTeamnameChange();
     }
   }

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -914,9 +914,6 @@ function clearForm() {
       document.getElementById("input_m").value = match + 1
     }
 
-    // Set default comment back to None
-    document.getElementById("input_Comments").value = "Reset";
-
     // Robot
     resetRobot();
   }
@@ -993,6 +990,12 @@ function clearForm() {
       }
     }
   }
+
+  // Reset comment field to default:
+  if (!pitScouting) {
+    document.getElementById("input_co").value = "None";
+  }
+
   drawFields()
 }
 

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -682,7 +682,7 @@ function configure() {
   if(mydata.hasOwnProperty('dataFormat')) {
     dataFormat = mydata.dataFormat;
   }
-  
+
   if (mydata.hasOwnProperty('title')) {
     document.title = mydata.title;
   }
@@ -876,7 +876,7 @@ function updateQRHeader() {
 
 function qr_regenerate() {
   // Validate required pre-match date (event, match, level, robot, scouter)
-  if (!pitScouting) {  
+  if (!pitScouting) {
     if (validateData() == false) {
       // Don't allow a swipe until all required data is filled in
       return false
@@ -1224,6 +1224,7 @@ function updateMatchStart(event) {
   if (event.target.id == "input_m") {
     if (getRobot() != "" && typeof getRobot()) {
       document.getElementById("input_t").value = getCurrentTeamNumberFromRobot().replace("frc", "");
+      document.getElementById("input_name").value = getTeamName(document.getElementById("input_t").value)
       onTeamnameChange();
     }
   }

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -1232,11 +1232,12 @@ function updateMatchStart(event) {
 function onTeamnameChange(event) {
   var newNumber = document.getElementById("input_t").value;
   var teamLabel = document.getElementById("teamname-label");
+  document.getElementById("input_n").value = 'DanTeam' //getTeamName(newNumber);
   if (newNumber != "") {
     teamLabel.innerText = getTeamName(newNumber) != "" ? "You are scouting " + getTeamName(newNumber) : "That team isn't playing this match, please double check to verify correct number";
   } else {
     teamLabel.innerText = "";
-    document.getElementById("input_n").value = teamLabel;
+    document.getElementById("input_n").value = 'DanTeam' //getTeamName(newNumber);
   }
 }
 

--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -915,10 +915,10 @@ function clearForm() {
     }
 
     // Set default comment back to None
-    document.getElementById("input_Comments").value = "Reset"
+    document.getElementById("input_Comments").value = "Reset";
 
     // Robot
-    resetRobot()
+    resetRobot();
   }
 
   // Clear XY coordinates


### PR DESCRIPTION
This PR updates values and some behavior based on our experience at Lake City. 

Changes include,

- Team names are added through an auto-populating text box.
- Climbing behavior language is clarified.
- There is now a checkbox for WOULD and WOULD NOT select for an alliance.
- Comments defaults to None and resets to None on form clear.
- One boolean checkbox for Died/Immobilized/Game piece Stuck

The spreadsheet on google drive has been updated to match the changed input values.